### PR TITLE
get BepInEx config path programmatically

### DIFF
--- a/src/Configuration/PluginConfig.cs
+++ b/src/Configuration/PluginConfig.cs
@@ -34,7 +34,7 @@ namespace RandomEncounters.Configuration
 
         public static void Initialize()
         {
-            var configFolder = Path.Combine("BepInEx", "config", Plugin.PluginName);
+            var configFolder = Path.Combine(BepInEx.Paths.BepInExConfigPath, Plugin.PluginName);
             if (!Directory.Exists(configFolder))
             {
                 Directory.CreateDirectory(configFolder);

--- a/src/Configuration/PluginConfig.cs
+++ b/src/Configuration/PluginConfig.cs
@@ -34,7 +34,8 @@ namespace RandomEncounters.Configuration
 
         public static void Initialize()
         {
-            var configFolder = Path.Combine(BepInEx.Paths.BepInExConfigPath, Plugin.PluginName);
+            var bepInExConfigFolder = Path.GetDirectoryName(BepInEx.Paths.BepInExConfigPath) ?? Path.Combine("BepInEx", "config");
+            var configFolder = Path.Combine(bepInExConfigFolder, Plugin.PluginName);
             if (!Directory.Exists(configFolder))
             {
                 Directory.CreateDirectory(configFolder);


### PR DESCRIPTION
bepinex exposes the config path so we should use this otherwise the root directory of the game is used as the working directory but the bepinex config might not be in there in some cases (e.g. if the mod manager is used)